### PR TITLE
Enable windows authentication through console in RavenDb updates

### DIFF
--- a/product/roundhouse.databases.ravendb/commands/RavenCommand.cs
+++ b/product/roundhouse.databases.ravendb/commands/RavenCommand.cs
@@ -13,7 +13,10 @@ namespace roundhouse.databases.ravendb.commands
 
         public RavenCommand()
         {
-            _webClient = new WebClient();
+            _webClient = new WebClient
+            {
+                UseDefaultCredentials = true
+            };
         }
 
         public void Dispose()


### PR DESCRIPTION
When IIS only has windows authentication enabled, credentials should be passed
to the website. Setting the webclient to use default credentials will do this, allowing
support for windows authentication.